### PR TITLE
Enabled to open path with the associated application

### DIFF
--- a/src/com/junichi11/netbeans/showpath/ui/Bundle.properties
+++ b/src/com/junichi11/netbeans/showpath/ui/Bundle.properties
@@ -1,3 +1,4 @@
 ShowPathPanel.fullPathTextField.text=
 ShowPathPanel.pathLabel.text=Path:
 ShowPathPanel.copyButton.text=copy
+ShowPathPanel.openButton.text=open

--- a/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.form
+++ b/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.form
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <NonVisualComponents>
+    <Container class="javax.swing.JPanel" name="jPanel1">
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+    </Container>
+  </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -16,12 +33,14 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <Component id="pathLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="fullPathTextField" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="copyButton" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="openButton" min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -31,6 +50,7 @@
               <Component id="pathLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               <Component id="fullPathTextField" alignment="3" min="-2" max="-2" attributes="0"/>
               <Component id="copyButton" alignment="3" min="-2" max="-2" attributes="0"/>
+              <Component id="openButton" alignment="3" min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -55,6 +75,16 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="com/junichi11/netbeans/showpath/ui/Bundle.properties" key="ShowPathPanel.copyButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="ShowPathPanel_copyButton"/>
+      </AuxValues>
+    </Component>
+    <Component class="javax.swing.JButton" name="openButton">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="com/junichi11/netbeans/showpath/ui/Bundle.properties" key="ShowPathPanel.openButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.form
+++ b/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.form
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
-  <NonVisualComponents>
-    <Container class="javax.swing.JPanel" name="jPanel1">
-
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
-          </Group>
-        </DimensionLayout>
-      </Layout>
-    </Container>
-  </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -33,7 +16,7 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <Component id="pathLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="fullPathTextField" min="-2" max="-2" attributes="0"/>
@@ -77,9 +60,6 @@
           <ResourceString bundle="com/junichi11/netbeans/showpath/ui/Bundle.properties" key="ShowPathPanel.copyButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <AuxValues>
-        <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="ShowPathPanel_copyButton"/>
-      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="openButton">
       <Properties>

--- a/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.java
+++ b/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.java
@@ -75,22 +75,10 @@ public class ShowPathPanel extends JPanel implements LookupListener {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        jPanel1 = new javax.swing.JPanel();
         pathLabel = new javax.swing.JLabel();
         fullPathTextField = new javax.swing.JTextField();
         copyButton = new javax.swing.JButton();
         openButton = new javax.swing.JButton();
-
-        javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
-        jPanel1.setLayout(jPanel1Layout);
-        jPanel1Layout.setHorizontalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 100, Short.MAX_VALUE)
-        );
-        jPanel1Layout.setVerticalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 100, Short.MAX_VALUE)
-        );
 
         org.openide.awt.Mnemonics.setLocalizedText(pathLabel, org.openide.util.NbBundle.getMessage(ShowPathPanel.class, "ShowPathPanel.pathLabel.text")); // NOI18N
 
@@ -127,7 +115,6 @@ public class ShowPathPanel extends JPanel implements LookupListener {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton copyButton;
     private javax.swing.JTextField fullPathTextField;
-    private javax.swing.JPanel jPanel1;
     private javax.swing.JButton openButton;
     private javax.swing.JLabel pathLabel;
     // End of variables declaration//GEN-END:variables

--- a/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.java
+++ b/src/com/junichi11/netbeans/showpath/ui/ShowPathPanel.java
@@ -24,6 +24,7 @@
 package com.junichi11.netbeans.showpath.ui;
 
 import com.junichi11.netbeans.showpath.ui.actions.CopyPathAction;
+import com.junichi11.netbeans.showpath.ui.actions.OpenPathAction;
 import java.io.File;
 import java.util.Collection;
 import javax.swing.JPanel;
@@ -52,6 +53,7 @@ public class ShowPathPanel extends JPanel implements LookupListener {
     private ShowPathPanel() {
         initComponents();
         copyButton.addActionListener(new CopyPathAction());
+        openButton.addActionListener(new OpenPathAction());
         addLookupListener();
     }
 
@@ -73,9 +75,22 @@ public class ShowPathPanel extends JPanel implements LookupListener {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
+        jPanel1 = new javax.swing.JPanel();
         pathLabel = new javax.swing.JLabel();
         fullPathTextField = new javax.swing.JTextField();
         copyButton = new javax.swing.JButton();
+        openButton = new javax.swing.JButton();
+
+        javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
+        jPanel1.setLayout(jPanel1Layout);
+        jPanel1Layout.setHorizontalGroup(
+            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGap(0, 100, Short.MAX_VALUE)
+        );
+        jPanel1Layout.setVerticalGroup(
+            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGap(0, 100, Short.MAX_VALUE)
+        );
 
         org.openide.awt.Mnemonics.setLocalizedText(pathLabel, org.openide.util.NbBundle.getMessage(ShowPathPanel.class, "ShowPathPanel.pathLabel.text")); // NOI18N
 
@@ -83,6 +98,8 @@ public class ShowPathPanel extends JPanel implements LookupListener {
         fullPathTextField.setText(org.openide.util.NbBundle.getMessage(ShowPathPanel.class, "ShowPathPanel.fullPathTextField.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(copyButton, org.openide.util.NbBundle.getMessage(ShowPathPanel.class, "ShowPathPanel.copyButton.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(openButton, org.openide.util.NbBundle.getMessage(ShowPathPanel.class, "ShowPathPanel.openButton.text")); // NOI18N
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
@@ -93,20 +110,25 @@ public class ShowPathPanel extends JPanel implements LookupListener {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(fullPathTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(copyButton))
+                .addComponent(copyButton)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(openButton))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                 .addComponent(pathLabel)
                 .addComponent(fullPathTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addComponent(copyButton))
+                .addComponent(copyButton)
+                .addComponent(openButton))
         );
     }// </editor-fold>//GEN-END:initComponents
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton copyButton;
     private javax.swing.JTextField fullPathTextField;
+    private javax.swing.JPanel jPanel1;
+    private javax.swing.JButton openButton;
     private javax.swing.JLabel pathLabel;
     // End of variables declaration//GEN-END:variables
 

--- a/src/com/junichi11/netbeans/showpath/ui/actions/OpenPathAction.java
+++ b/src/com/junichi11/netbeans/showpath/ui/actions/OpenPathAction.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 trashtoy.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.junichi11.netbeans.showpath.ui.actions;
+
+import com.junichi11.netbeans.showpath.ui.ShowPathPanel;
+import java.awt.Desktop;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+@ActionID(category = "Edit", id = "com.junichi11.netbeans.showpath.ui.actions.OpenPathAction")
+@ActionRegistration(displayName = "#CTL_OpenPathAction")
+@Messages("CTL_OpenPathAction=Open path with associated program")
+public final class OpenPathAction implements ActionListener {
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // get full path
+        ShowPathPanel showPathPanel = ShowPathPanel.getInstance();
+        String fullPath = showPathPanel.getFullPath();
+        if (fullPath.isEmpty()) {
+            return;
+        }
+
+        final Desktop desktop = java.awt.Desktop.getDesktop();
+        try {
+            desktop.open(new File(fullPath));
+        } catch (IOException ex) {
+            System.err.println(ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Placed "open" button to the right of "copy" button.

![open-button](https://cloud.githubusercontent.com/assets/731136/5833878/1992c73c-a19b-11e4-96a9-0b746b230ab4.png)

copy ボタンの右隣に "open" ボタンを追加しました.
Path: に表示されているファイルを関連づけられたプログラムで開きます.
例えば `C:\Users\(略)\test01.xlsx` を選択した状態で "open" ボタンを押下した場合, Microsoft Excel で対象のファイルを開きます.
フォルダが選択された状態で "open" ボタンを押下した場合は Explorer でそのフォルダを開きます.
Path: に表示されているファイルがない場合は何もしません.
